### PR TITLE
Fix linux support

### DIFF
--- a/src/main/java/jarhead/Main.java
+++ b/src/main/java/jarhead/Main.java
@@ -69,8 +69,10 @@ class Main extends JFrame {
             String path;
             if(os.contains("win"))
                 path = System.getenv("AppData") + "/RRPathGen/config.properties";
+            else if(os.contains("mac") || os.contains("darwin"))
+                path = System.getProperty("user.home") + "/Library/Application Support/RRPathGen/config.properties";
             else
-                path = System.getProperty("user.home") + "/Library/Application Support/RRPathGen/config.properties"; //just assume its mac
+                path = System.getProperty("user.home") + "/.RRPathGen/config.properties";
             configPath = path;
             File file = new File(path);
             if(!file.exists()) {


### PR DESCRIPTION
Closes #2 
Allows to detect whether the user is on Mac or Linux, and change the config file path depending on it.
Works on Linux, but I have not tested on Windows or Mac.