### PR TITLE
Implemented limit for size of NodeManager.undo and ctrl+y shortcut for redo

### DIFF
--- a/src/main/java/jarhead/DrawPanel.java
+++ b/src/main/java/jarhead/DrawPanel.java
@@ -350,18 +350,16 @@ public class DrawPanel extends JPanel {
 
         Graphics g = preRenderedSplines.getGraphics();
         for (NodeManager manager : managers){
-            if(!manager.equals(getCurrentManager())){
-                if(manager.size() > 0) {
-                    Node node = manager.getNodes().get(0);
-                    TrajectorySequence trajectory = generateTrajectory(manager, node);
-                    if(trajectory != null) {
-                        renderRobotPath((Graphics2D) g, trajectory, dLightPurple, 0.5f);
-                        renderSplines(g, trajectory, cyan);
-                        renderPoints(g, trajectory, cyan, 1);
-                    }
-                    renderArrows(g, manager, 1, dDarkPurple, dLightPurple, dCyan);
-                }
+            if(manager.equals(getCurrentManager())) continue;
+            if(manager.size() <= 0) continue;
+            Node node = manager.getNodes().get(0);
+            TrajectorySequence trajectory = generateTrajectory(manager, node);
+            if(trajectory != null) {
+                renderRobotPath((Graphics2D) g, trajectory, dLightPurple, 0.5f);
+                renderSplines(g, trajectory, cyan);
+                renderPoints(g, trajectory, cyan, 1);
             }
+            renderArrows(g, manager, 1, dDarkPurple, dLightPurple, dCyan);
         }
         g.dispose();
     }
@@ -517,7 +515,7 @@ public class DrawPanel extends JPanel {
 
             mouse = snap(mouse, e);
             if(index != -1){
-                if(SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 1) {
+                if(e.getClickCount() == 1) {
                     getCurrentManager().editIndex = index;
                     edit = true;
                     //if the point clicked was a mid point, gen a new point

--- a/src/main/java/jarhead/DrawPanel.java
+++ b/src/main/java/jarhead/DrawPanel.java
@@ -664,7 +664,10 @@ public class DrawPanel extends JPanel {
                 }
                 break;
             case KeyEvent.VK_Z:
-                if(e.isControlDown()) main.undo();
+                if(e.isControlDown()) main.undo(true);
+                break;
+            case KeyEvent.VK_Y:
+                if(e.isControlDown()) main.redo();
                 break;
             case KeyEvent.VK_DELETE:
             case KeyEvent.VK_BACK_SPACE:

--- a/src/main/java/jarhead/Main.java
+++ b/src/main/java/jarhead/Main.java
@@ -151,7 +151,7 @@ class Main extends JFrame {
 
     public void undo(boolean record){
         if(getCurrentManager().undo.size()<1) return;
-        Node node = getCurrentManager().undo.last();
+        Node node = getCurrentManager().undo.peek();
         switch (node.state) {
             case ADD:
                 node = getCurrentManager().get(node.index);
@@ -177,11 +177,11 @@ class Main extends JFrame {
                 break;
         }
         if (record) getCurrentManager().redo.add(node);
-        getCurrentManager().undo.removeLast();
+        getCurrentManager().undo.pop();
     }
     public void redo(){
         if(getCurrentManager().redo.size()<1) return;
-        Node node = getCurrentManager().redo.last();
+        Node node = getCurrentManager().redo.peek();
 
         //TODO: fix undo and redo
         switch (node.state){
@@ -208,7 +208,7 @@ class Main extends JFrame {
                 break;
         }
         getCurrentManager().undo.add(node);
-        getCurrentManager().redo.removeLast();
+        getCurrentManager().redo.pop();
     }
 
     public void saveConfig() {
@@ -222,6 +222,12 @@ class Main extends JFrame {
     public void scale(NodeManager manager, double ns, double os){
         for (int j = 0; j < manager.size(); j++) {
             Node n = manager.get(j);
+            n.x = (n.x/os)*ns;
+            n.y = (n.y/os)*ns;
+        }
+    }
+    public void scale(Stack<Node> manager, double ns, double os){
+        for (Node n : manager) {
             n.x = (n.x/os)*ns;
             n.y = (n.y/os)*ns;
         }

--- a/src/main/java/jarhead/Main.java
+++ b/src/main/java/jarhead/Main.java
@@ -149,10 +149,6 @@ class Main extends JFrame {
         }
     }
 
-    public void undo(){
-        undo(false);
-    }
-
     public void undo(boolean record){
         if(getCurrentManager().undo.size()<1) return;
         Node node = getCurrentManager().undo.last();
@@ -161,6 +157,7 @@ class Main extends JFrame {
                 node = getCurrentManager().get(node.index);
                 node.state = Node.State.ADD;
                 getCurrentManager().remove(node.index);
+                currentN = node.index-1;
                 break;
             case DELETE:
                 getCurrentManager().add(node.index, node);

--- a/src/main/java/jarhead/NodeManager.java
+++ b/src/main/java/jarhead/NodeManager.java
@@ -1,15 +1,15 @@
 package jarhead;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 public class NodeManager {
 
-    public NodeManager undo;
-    public NodeManager redo;
+    public SizedStack<Node> undo;
+    // SizedStack isn't needed for redo since it cannot ever be larger than undo
+    public Stack<Node> redo;
     public int editIndex = -1;
     private ArrayList nodes;
     public String name;
@@ -23,10 +23,8 @@ public class NodeManager {
         this.nodes = nodes;
         this.id = id;
         this.name = name;
-        if(id != -1){
-            undo = new NodeManager(new ArrayList<>(), -1);
-            redo = new NodeManager(new ArrayList<>(), -1);
-        }
+        undo = new SizedStack<>(50);
+        redo = new Stack<>();
     }
 
     public Node get(int index){
@@ -58,9 +56,7 @@ public class NodeManager {
     public void remove(int n){
         nodes.remove(n);
     }
-    public void removeLast(){
-        remove(size()-1);
-    }
+
     public List<Marker> getMarkers(){
         return (List<Marker>) nodes.stream().filter(node -> node instanceof Marker).collect(Collectors.toList());
     }

--- a/src/main/java/jarhead/SizedStack.java
+++ b/src/main/java/jarhead/SizedStack.java
@@ -1,0 +1,21 @@
+package jarhead;
+
+import java.util.Stack;
+
+public class SizedStack<Node> extends Stack<Node> {
+    private final int maxSize;
+
+    public SizedStack(int size) {
+        super();
+        this.maxSize = size;
+    }
+
+    @Override
+    public Node push(Node object) {
+        // if the stack is too big, remove elements until it's the right size
+        while (this.size() >= maxSize) {
+            this.remove(0);
+        }
+        return super.push(object);
+    }
+}


### PR DESCRIPTION
Added a ctrl+y shortcut for redo as outlined in #13
Also changed the undo shortcut to record the undo, because then ctrl+y could be added

Converted NodeManager.undo to a SizedStack which extends java.util.Stack, and redo to a Stack in order to limit the number of events that undo records (resolves #18)
When the limit is reached, elements at the start of the stack are removed until it is below the limit (which technically isn't LIFO but ehh)